### PR TITLE
separate "host" and "port" for icy.request

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -16,13 +16,15 @@ export const icyRequest = async (url, func, options = {}) => {
     } = options;
     const urlInfo = new URL(url);
     const {
-        host,
+        hostname,
+        port,
         pathname: path,
         protocol,
     } = urlInfo;
 
     const params = {
-        host,
+        host: hostname,
+        port,
         path,
         protocol,
         method,


### PR DESCRIPTION
Fixes #5

An issue arises as a result of `host` being passed directly from the `URL` object to `icy.request`:

- Node's `URL.host` embeds the port number in the value, *but*
- Node's `http.request` (what icy uses) requires `host` and `port` to be specified as separate options keys

This PR replaces `URL.host` with `URL.hostname` such that `port` can be assigned and passed as a separate key.